### PR TITLE
Add constantine to fuzzing tests

### DIFF
--- a/build_constantine.sh
+++ b/build_constantine.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+if ! (type nim > /dev/null); then
+    msg="ERROR: Nim installation not found. Please install Nim, which \
+is required to build Constantine's shared library. Read Constantine's \
+README at
+https://github.com/mratsim/constantine
+and follow the instructions \
+there to install Nim or head to
+https://nim-lang.org"
+    echo "$msg"
+    exit 1
+else
+    echo "Nim installation found, continuing..."
+fi
+
+if [ ! -d constantine ]; then
+    git clone https://github.com/mratsim/constantine
+else
+    echo "Constantine repository already exists, skipping clone."
+fi
+
+if [ ! -f constantine/lib/libconstantine.so ]; then
+    cd constantine
+    CC=clang nimble make_lib
+else
+    echo "Constantine library already built."
+fi

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,14 @@
 module fuzz
 
-go 1.19
+go 1.21.5
+
+toolchain go1.22.0
 
 require (
 	github.com/crate-crypto/go-kzg-4844 v0.7.0
 	github.com/ethereum/c-kzg-4844 v0.4.1
 	github.com/holiman/uint256 v1.2.1
+	github.com/mratsim/constantine v0.0.0-20240614095347-9fe5e495f7f8
 	github.com/protolambda/go-kzg v0.0.0-20221224134646-c91cee5e954e
 )
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,9 @@ require (
 	github.com/protolambda/go-kzg v0.0.0-20221224134646-c91cee5e954e
 )
 
+// use our local constantine build from `build_constantine.sh`
+replace github.com/mratsim/constantine => ./constantine
+
 require (
 	github.com/bits-and-blooms/bitset v1.5.0 // indirect
 	github.com/consensys/bavard v0.1.13 // indirect

--- a/main_test.go
+++ b/main_test.go
@@ -153,7 +153,7 @@ func FuzzVerifyKZGProof(f *testing.F) {
 	})
 }
 
-func FuzzVerifyBlobKZGProof(f *testing.F) {
+func FuzzVerifyBlobKZGProofSingle(f *testing.F) {
 	f.Fuzz(func(t *testing.T, seed int64) {
 		cKzgBlob, goKzgBlob, ok := GetRandBlob(t, seed)
 		if !ok {

--- a/main_test.go
+++ b/main_test.go
@@ -7,10 +7,12 @@ import (
 
 	gokzg "github.com/crate-crypto/go-kzg-4844"
 	ckzg "github.com/ethereum/c-kzg-4844/bindings/go"
+	ctt "github.com/mratsim/constantine/constantine-go"
 	"github.com/stretchr/testify/require"
 )
 
 var gokzgCtx *gokzg.Context
+var cttKzgCtx ctt.EthKzgContext
 
 func TestMain(m *testing.M) {
 	err := ckzg.LoadTrustedSetupFile("trusted_setup.txt")
@@ -21,6 +23,13 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic("Failed to create context")
 	}
+
+	cttKzgCtx, err = ctt.EthKzgContextNew("trusted_setup.txt")
+	if err != nil {
+		panic("Failed to create context or load trusted setup")
+	}
+	defer cttKzgCtx.Delete()
+
 
 	code := m.Run()
 
@@ -34,79 +43,91 @@ func TestMain(m *testing.M) {
 
 func FuzzBlobToKZGCommitment(f *testing.F) {
 	f.Fuzz(func(t *testing.T, seed int64) {
-		cKzgBlob, goKzgBlob, ok := GetRandBlob(t, seed)
+		cKzgBlob, goKzgBlob, cttKzgBlob, ok := GetRandBlob(t, seed)
 		if !ok {
 			t.SkipNow()
 		}
 
 		cKzgCommitment, cKzgErr := ckzg.BlobToKZGCommitment(cKzgBlob)
 		goKzgCommitment, goKzgErr := gokzgCtx.BlobToKZGCommitment(goKzgBlob, 1)
+		cttKzgCommitment, cttKzgErr := cttKzgCtx.BlobToKzgCommitment(cttKzgBlob)
 
 		require.Equal(t, cKzgErr == nil, goKzgErr == nil)
-		if cKzgErr == nil && goKzgErr == nil {
+		require.Equal(t, cKzgErr == nil, cttKzgErr == nil)
+		if cKzgErr == nil && goKzgErr == nil && cttKzgErr == nil {
 			require.Equal(t, cKzgCommitment[:], goKzgCommitment[:])
+			require.Equal(t, cttKzgCommitment[:], cttKzgCommitment[:])
 		}
 	})
 }
 
 func FuzzComputeKZGProof(f *testing.F) {
 	f.Fuzz(func(t *testing.T, seed int64) {
-		cKzgBlob, goKzgBlob, ok := GetRandBlob(t, seed)
+		cKzgBlob, goKzgBlob, cttKzgBlob, ok := GetRandBlob(t, seed)
 		if !ok {
 			t.SkipNow()
 		}
-		cKzgZ, goKzgZ, ok := GetRandFieldElement(t, seed)
+		cKzgZ, goKzgZ, cttKzgZ, ok := GetRandFieldElement(t, seed)
 		if !ok {
 			t.SkipNow()
 		}
 
 		cKzgProof, cKzgY, cKzgErr := ckzg.ComputeKZGProof(cKzgBlob, cKzgZ)
 		goKzgProof, goKzgY, goKzgErr := gokzgCtx.ComputeKZGProof(goKzgBlob, goKzgZ, 1)
+		cttKzgProof, cttKzgY, cttKzgErr := cttKzgCtx.ComputeKzgProof(cttKzgBlob, cttKzgZ)
 
 		require.Equal(t, cKzgErr == nil, goKzgErr == nil)
+		require.Equal(t, cKzgErr == nil, cttKzgErr == nil)
 		if cKzgErr == nil && goKzgErr == nil {
 			require.Equal(t, cKzgProof[:], goKzgProof[:])
 			require.Equal(t, cKzgY[:], goKzgY[:])
+			require.Equal(t, cKzgProof[:], cttKzgProof[:])
+			require.Equal(t, cKzgY[:], cttKzgY[:])
 		}
 	})
 }
 
 func FuzzComputeBlobKZGProof(f *testing.F) {
 	f.Fuzz(func(t *testing.T, seed int64) {
-		cKzgBlob, goKzgBlob, ok := GetRandBlob(t, seed)
+		cKzgBlob, goKzgBlob, cttKzgBlob, ok := GetRandBlob(t, seed)
 		if !ok {
 			t.SkipNow()
 		}
-		cKzgCommitment, goKzgCommitment, ok := GetRandCommitment(t, seed)
+		cKzgCommitment, goKzgCommitment, cttKzgCommitment, ok := GetRandCommitment(t, seed)
 		if !ok {
 			t.SkipNow()
 		}
 
 		cKzgProof, cKzgErr := ckzg.ComputeBlobKZGProof(cKzgBlob, cKzgCommitment)
 		goKzgProof, goKzgErr := gokzgCtx.ComputeBlobKZGProof(goKzgBlob, goKzgCommitment, 1)
+		cttKzgProof, cttKzgErr := cttKzgCtx.ComputeBlobKzgProof(cttKzgBlob, cttKzgCommitment)
 
 		require.Equal(t, cKzgErr == nil, goKzgErr == nil)
-		if cKzgErr == nil && goKzgErr == nil {
+		require.Equal(t, cKzgErr == nil, cttKzgErr == nil)
+		if cKzgErr == nil && goKzgErr == nil && cttKzgErr == nil {
 			require.Equal(t, cKzgProof[:], goKzgProof[:])
+			require.Equal(t, cKzgProof[:], cttKzgProof[:])
 		}
 	})
 }
 
 func FuzzVerifyKZGProof(f *testing.F) {
 	f.Fuzz(func(t *testing.T, seed int64) {
-		cKzgCommitment, goKzgCommitment, ok := GetRandCommitment(t, seed)
+		cKzgCommitment, goKzgCommitment, cttKzgCommitment, ok := GetRandCommitment(t, seed)
 		if !ok {
 			t.SkipNow()
 		}
-		cKzgZ, goKzgZ, ok := GetRandFieldElement(t, seed)
+		cKzgZ, goKzgZ, cttKzgZ, ok := GetRandFieldElement(t, seed)
 		if !ok {
 			t.SkipNow()
 		}
-		cKzgY, goKzgY, ok := GetRandFieldElement(t, seed)
+		cKzgY, goKzgY, cttKzgYCh, ok := GetRandFieldElement(t, seed)
+		// Need to convert the ctt.EthKzgChallenge to the correct type returned by ctt.ComputeKzgProof
+		var cttKzgY ctt.EthKzgEvalAtChallenge = ctt.EthKzgEvalAtChallenge(cttKzgYCh)
 		if !ok {
 			t.SkipNow()
 		}
-		cKzgProof, goKzgProof, ok := GetRandProof(t, seed)
+		cKzgProof, goKzgProof, cttKzgProof, ok := GetRandProof(t, seed)
 		if !ok {
 			t.SkipNow()
 		}
@@ -117,7 +138,7 @@ func FuzzVerifyKZGProof(f *testing.F) {
 			var cKzgProofTrusted ckzg.KZGProof
 
 			// Generate a blob that'll be used to make a commitment/proof
-			cKzgBlob, goKzgBlob, ok := GetRandBlob(t, seed)
+			cKzgBlob, goKzgBlob, cttKzgBlob, ok := GetRandBlob(t, seed)
 			if !ok {
 				t.SkipNow()
 			}
@@ -126,75 +147,95 @@ func FuzzVerifyKZGProof(f *testing.F) {
 			cKzgCommitmentTrusted, cKzgErr := ckzg.BlobToKZGCommitment(cKzgBlob)
 			cKzgCommitment = ckzg.Bytes48(cKzgCommitmentTrusted)
 			goKzgCommitment, goKzgErr = gokzgCtx.BlobToKZGCommitment(goKzgBlob, 1)
+			cttKzgCommitment, cttKzgErr := cttKzgCtx.BlobToKzgCommitment(cttKzgBlob)
 			require.Equal(t, cKzgErr == nil, goKzgErr == nil)
-			if cKzgErr == nil && goKzgErr == nil {
+			require.Equal(t, cKzgErr == nil, cttKzgErr == nil)
+			if cKzgErr == nil && goKzgErr == nil && cttKzgErr == nil {
 				require.Equal(t, cKzgCommitment[:], goKzgCommitment[:])
+				require.Equal(t, cKzgCommitment[:], cttKzgCommitment[:])
 			}
 
 			// Generate a KZGProof to that blob/point
 			cKzgProofTrusted, cKzgY, cKzgErr = ckzg.ComputeKZGProof(cKzgBlob, cKzgZ)
 			cKzgProof = ckzg.Bytes48(cKzgProofTrusted)
 			goKzgProof, goKzgY, goKzgErr = gokzgCtx.ComputeKZGProof(goKzgBlob, goKzgZ, 1)
+			cttKzgProof, cttKzgY, cttKzgErr = cttKzgCtx.ComputeKzgProof(cttKzgBlob, cttKzgZ)
 			require.Equal(t, cKzgErr == nil, goKzgErr == nil)
-			if cKzgErr == nil && goKzgErr == nil {
+			require.Equal(t, cKzgErr == nil, cttKzgErr == nil)
+			if cKzgErr == nil && goKzgErr == nil && cttKzgErr == nil {
 				require.Equal(t, cKzgProof[:], goKzgProof[:])
+				require.Equal(t, cKzgProof[:], cttKzgProof[:])
 			}
 		}
 
 		cKzgResult, cKzgErr := ckzg.VerifyKZGProof(cKzgCommitment, cKzgZ, cKzgY, cKzgProof)
 		goKzgErr := gokzgCtx.VerifyKZGProof(goKzgCommitment, goKzgZ, goKzgY, goKzgProof)
 		goKzgResult := goKzgErr == nil
+		cttKzgResult, cttKzgErr := cttKzgCtx.VerifyKzgProof(cttKzgCommitment, cttKzgZ, cttKzgY, cttKzgProof)
 
 		t.Logf("go-kzg error: %v\n", cKzgErr)
 		require.Equal(t, cKzgErr == nil, goKzgErr == nil)
-		if cKzgErr == nil && goKzgErr == nil {
+		require.Equal(t, cKzgErr == nil, cttKzgErr == nil)
+		if cKzgErr == nil && goKzgErr == nil && cttKzgErr == nil {
 			require.Equal(t, cKzgResult, goKzgResult)
+			require.Equal(t, cKzgResult, cttKzgResult)
 		}
 	})
 }
 
 func FuzzVerifyBlobKZGProofSingle(f *testing.F) {
 	f.Fuzz(func(t *testing.T, seed int64) {
-		cKzgBlob, goKzgBlob, ok := GetRandBlob(t, seed)
+		cKzgBlob, goKzgBlob, cttKzgBlob, ok := GetRandBlob(t, seed)
 		if !ok {
 			t.SkipNow()
 		}
-		cKzgCommitment, goKzgCommitment, ok := GetRandCommitment(t, seed)
+		cKzgCommitment, goKzgCommitment, cttKzgCommitment, ok := GetRandCommitment(t, seed)
 		if !ok {
 			t.SkipNow()
 		}
-		cKzgProof, goKzgProof, ok := GetRandProof(t, seed)
+		cKzgProof, goKzgProof, cttKzgProof, ok := GetRandProof(t, seed)
 		if !ok {
 			t.SkipNow()
 		}
 
 		if seed%2 == 0 {
-			var cKzgErr, goKzgErr error
+			var cKzgErr, goKzgErr, cttKzgErr error
 			var cKzgProofTrusted ckzg.KZGProof
 
 			// Generate a KZGProof to that blob/commitment
 			cKzgProofTrusted, cKzgErr = ckzg.ComputeBlobKZGProof(cKzgBlob, cKzgCommitment)
 			cKzgProof = ckzg.Bytes48(cKzgProofTrusted)
 			goKzgProof, goKzgErr = gokzgCtx.ComputeBlobKZGProof(goKzgBlob, goKzgCommitment, 1)
+			cttKzgProof, cttKzgErr = cttKzgCtx.ComputeBlobKzgProof(cttKzgBlob, cttKzgCommitment)
 			require.Equal(t, cKzgErr == nil, goKzgErr == nil)
-			if cKzgErr == nil && goKzgErr == nil {
+			require.Equal(t, cKzgErr == nil, cttKzgErr == nil)
+			if cKzgErr == nil && goKzgErr == nil && cttKzgErr == nil {
 				require.Equal(t, cKzgProof[:], goKzgProof[:])
+				require.Equal(t, cKzgProof[:], cttKzgProof[:])
 			}
 		}
 
 		cKzgResult, cKzgErr := ckzg.VerifyBlobKZGProof(cKzgBlob, cKzgCommitment, cKzgProof)
 		goKzgErr := gokzgCtx.VerifyBlobKZGProof(goKzgBlob, goKzgCommitment, goKzgProof)
 		goKzgResult := goKzgErr == nil
+		cttKzgResult, cttKzgErr := cttKzgCtx.VerifyBlobKzgProof(cttKzgBlob, cttKzgCommitment, cttKzgProof)
+
 
 		t.Logf("go-kzg error: %v\n", cKzgErr)
 		require.Equal(t, cKzgErr == nil, goKzgErr == nil)
-		if cKzgErr == nil && goKzgErr == nil {
+		require.Equal(t, cKzgErr == nil, cttKzgErr == nil)
+		if cKzgErr == nil && goKzgErr == nil && cttKzgErr == nil {
 			require.Equal(t, cKzgResult, goKzgResult)
+			require.Equal(t, cKzgResult, cttKzgResult)
 		}
 	})
 }
 
 func FuzzVerifyBlobKZGProofBatch(f *testing.F) {
+	// Generate a single set of random bytes for constantine's batch verify
+	var secureRandomBytes [32]byte
+	_, _ = rand.Read(secureRandomBytes[:])
+
 	f.Fuzz(func(t *testing.T, seed int64) {
 
 		// Between 1 and 5, inclusive
@@ -206,6 +247,9 @@ func FuzzVerifyBlobKZGProofBatch(f *testing.F) {
 		goKzgBlobs := make([]gokzg.Blob, count)
 		goKzgCommitments := make([]gokzg.KZGCommitment, count)
 		goKzgProofs := make([]gokzg.KZGProof, count)
+		cttKzgBlobs := make([]ctt.EthBlob, count)
+		cttKzgCommitments := make([]ctt.EthKzgCommitment, count)
+		cttKzgProofs := make([]ctt.EthKzgProof, count)
 
 		for i := 0; i < int(count); i++ {
 			var cKzgBlob ckzg.Blob
@@ -214,33 +258,39 @@ func FuzzVerifyBlobKZGProofBatch(f *testing.F) {
 			var goKzgBlob gokzg.Blob
 			var goKzgCommitment gokzg.KZGCommitment
 			var goKzgProof gokzg.KZGProof
+			var cttKzgBlob ctt.EthBlob
+			var cttKzgCommitment ctt.EthKzgCommitment
+			var cttKzgProof ctt.EthKzgProof
 
 			completelyRandom := rand.Intn(2) != 0
 			if completelyRandom {
 				var ok bool
-				cKzgBlob, goKzgBlob, ok = GetRandBlob(t, seed)
+				cKzgBlob, goKzgBlob, cttKzgBlob, ok = GetRandBlob(t, seed)
 				if !ok {
 					t.SkipNow()
 				}
-				cKzgCommitment, goKzgCommitment, ok = GetRandCommitment(t, seed)
+				cKzgCommitment, goKzgCommitment, cttKzgCommitment, ok = GetRandCommitment(t, seed)
 				if !ok {
 					t.SkipNow()
 				}
-				cKzgProof, goKzgProof, ok = GetRandProof(t, seed)
+				cKzgProof, goKzgProof, cttKzgProof, ok = GetRandProof(t, seed)
 				if !ok {
 					t.SkipNow()
 				}
 			} else {
-				var cKzgErr, goKzgErr error
+				var cKzgErr, goKzgErr, cttKzgErr error
 				var cKzgProofTrusted ckzg.KZGProof
 
 				// Generate a KZGProof to that blob/commitment
 				cKzgProofTrusted, cKzgErr = ckzg.ComputeBlobKZGProof(cKzgBlob, cKzgCommitment)
 				cKzgProof = ckzg.Bytes48(cKzgProofTrusted)
 				goKzgProof, goKzgErr = gokzgCtx.ComputeBlobKZGProof(goKzgBlob, goKzgCommitment, 1)
+				cttKzgProof, cttKzgErr = cttKzgCtx.ComputeBlobKzgProof(cttKzgBlob, cttKzgCommitment)
 				require.Equal(t, cKzgErr == nil, goKzgErr == nil)
-				if cKzgErr == nil && goKzgErr == nil {
+				require.Equal(t, cKzgErr == nil, cttKzgErr == nil)
+				if cKzgErr == nil && goKzgErr == nil && cttKzgErr == nil {
 					require.Equal(t, cKzgProof[:], goKzgProof[:])
+					require.Equal(t, cKzgProof[:], cttKzgProof[:])
 				}
 			}
 
@@ -251,16 +301,23 @@ func FuzzVerifyBlobKZGProofBatch(f *testing.F) {
 			goKzgBlobs[i] = goKzgBlob
 			goKzgCommitments[i] = goKzgCommitment
 			goKzgProofs[i] = goKzgProof
+
+			cttKzgBlobs[i] = cttKzgBlob
+			cttKzgCommitments[i] = cttKzgCommitment
+			cttKzgProofs[i] = cttKzgProof
 		}
 
 		cKzgResult, cKzgErr := ckzg.VerifyBlobKZGProofBatch(cKzgBlobs, cKzgCommitments, cKzgProofs)
 		goKzgErr := gokzgCtx.VerifyBlobKZGProofBatch(goKzgBlobs, goKzgCommitments, goKzgProofs)
 		goKzgResult := goKzgErr == nil
+		cttKzgResult, cttKzgErr := cttKzgCtx.VerifyBlobKzgProofBatch(cttKzgBlobs, cttKzgCommitments, cttKzgProofs, secureRandomBytes)
 
 		t.Logf("go-kzg error: %v\n", cKzgErr)
 		require.Equal(t, cKzgErr == nil, goKzgErr == nil)
-		if cKzgErr == nil && goKzgErr == nil {
+		require.Equal(t, cKzgErr == nil, cttKzgErr == nil)
+		if cKzgErr == nil && goKzgErr == nil && cttKzgErr == nil {
 			require.Equal(t, cKzgResult, goKzgResult)
+			require.Equal(t, cKzgResult, cttKzgResult)
 		}
 	})
 }


### PR DESCRIPTION
This PR adds [Constantine](https://github.com/mratsim/constantine) to the fuzzing tests.

I took the liberty to rename the `FuzzVerifyBlobKZGProof` test to `FuzzVerifyBlobKZGProofSingle`, because I couldn't figure out how to run that test on its own. It would throw a
```
testing: will not fuzz, -fuzz matches more than one fuzz test: [FuzzVerifyBlobKZGProof FuzzVerifyBlobKZGProofBatch]
``` 
error. 

Note: right now there's an issue with the Constantine dependency. We need to build Constantine's shared library (based on the Nim code), but I'm not sure if there's a way to tell Go to do it automatically.


### Edit

Forgot  to mention: 
I noticed that the first fuzzing test `FuzzBlobToKZGCommitment` would randomly fail after a short time (even before adding Constantine). But rerunning the failed test cases would make them pass. 


### Edit 2

For the time being I decided to add a `build_constantine.sh` to the repo. If we consider to merge it like this, I'll add a section to the README mentioning it.